### PR TITLE
UnivariatePolynomial wraps UnivariateExprPolynomial, which has map_in…

### DIFF
--- a/symengine/dict.cpp
+++ b/symengine/dict.cpp
@@ -92,6 +92,11 @@ std::ostream &operator<<(std::ostream &out, const SymEngine::set_basic &d)
     return SymEngine::print_vec_rcp(out, d);
 }
 
+std::ostream &operator<<(std::ostream &out, const SymEngine::map_int_Expr &d)
+{
+    return SymEngine::print_map(out, d);
+}
+
 bool vec_basic_eq(const vec_basic &a, const vec_basic &b)
 {
     // Can't be equal if # of entries differ:

--- a/symengine/dict.h
+++ b/symengine/dict.h
@@ -156,6 +156,7 @@ std::ostream &operator<<(std::ostream &out,
                          const SymEngine::umap_basic_basic &d);
 std::ostream &operator<<(std::ostream &out, const SymEngine::vec_basic &d);
 std::ostream &operator<<(std::ostream &out, const SymEngine::set_basic &d);
+std::ostream &operator<<(std::ostream &out, const SymEngine::map_int_Expr &d);
 
 } // SymEngine
 

--- a/symengine/polynomial.cpp
+++ b/symengine/polynomial.cpp
@@ -359,9 +359,9 @@ RCP<const UnivariateIntPolynomial> mul_poly(const UnivariateIntPolynomial &a,
 UnivariatePolynomial::UnivariatePolynomial(const RCP<const Symbol> &var,
                                            const int &degree,
                                            const map_int_Expr &&dict)
-    : degree_{degree}, var_{var}, dict_{std::move(dict)}
+    : degree_{degree}, var_{var}, dict_{UnivariateExprPolynomial(std::move(dict))}
 {
-    SYMENGINE_ASSERT(is_canonical(degree_, dict_))
+    SYMENGINE_ASSERT(is_canonical(degree_, dict_.get_dict()))
 }
 
 UnivariatePolynomial::UnivariatePolynomial(const RCP<const Symbol> &var,
@@ -370,20 +370,20 @@ UnivariatePolynomial::UnivariatePolynomial(const RCP<const Symbol> &var,
 {
     for (unsigned int i = 0; i < v.size(); i++)
         if (v[i] != 0)
-            dict_add_term(dict_, v[i], i);
+            dict_.dict_add_term(v[i], i);
     degree_ = v.size() - 1;
     SYMENGINE_ASSERT(is_canonical(degree_, dict_))
 }
 
 bool UnivariatePolynomial::is_canonical(const int &degree_,
-                                        const map_int_Expr &dict) const
+                                        const UnivariateExprPolynomial &dict) const
 {
     if (var_->get_name() == "")
-        if (!(dict.empty() or (dict.size() == 1 and dict.begin()->first == 0)))
+        if (!(dict.empty() or (dict.size() == 1 and dict.get_dict().begin()->first == 0)))
             return false;
 
     if (dict.size() != 0) {
-        int prev_degree = (--dict.end())->first;
+        int prev_degree = (--dict.get_dict().end())->first;
         if (prev_degree != degree_) {
             return false;
         }
@@ -391,7 +391,7 @@ bool UnivariatePolynomial::is_canonical(const int &degree_,
         return false;
 
     // Check if dictionary contains terms with coeffienct 0
-    for (auto iter : dict)
+    for (auto iter : dict.get_dict())
         if (iter.first != 0 and iter.second == 0)
             return false;
     return true;
@@ -403,12 +403,7 @@ std::size_t UnivariatePolynomial::__hash__() const
     std::size_t seed = UNIVARIATEPOLYNOMIAL;
 
     seed += hash_string(this->var_->get_name());
-    for (const auto &it : this->dict_) {
-        std::size_t temp = UNIVARIATEPOLYNOMIAL;
-        hash_combine<unsigned int>(temp, it.first);
-        hash_combine<Basic>(temp, *(it.second.get_basic()));
-        seed += temp;
-    }
+    seed += dict_.__hash__();
     return seed;
 }
 
@@ -416,7 +411,7 @@ bool UnivariatePolynomial::__eq__(const Basic &o) const
 {
     return eq(*var_, *(static_cast<const UnivariatePolynomial &>(o).var_))
            and map_int_Expr_eq(
-                   dict_, static_cast<const UnivariatePolynomial &>(o).dict_);
+                   dict_.get_dict(), static_cast<const UnivariatePolynomial &>(o).dict_.get_dict());
 }
 
 int UnivariatePolynomial::compare(const Basic &o) const
@@ -431,7 +426,7 @@ int UnivariatePolynomial::compare(const Basic &o) const
     if (cmp != 0)
         return cmp;
 
-    return map_int_Expr_compare(dict_, s.dict_);
+    return map_int_Expr_compare(dict_.get_dict(), s.dict_.get_dict());
 }
 
 RCP<const UnivariatePolynomial>
@@ -459,18 +454,10 @@ UnivariatePolynomial::from_dict(const RCP<const Symbol> &var, map_int_Expr &&d)
     return make_rcp<const UnivariatePolynomial>(var, degree, std::move(d));
 }
 
-void UnivariatePolynomial::dict_add_term(map_int_Expr &d,
-                                         const Expression &coef, const int &n)
-{
-    auto it = d.find(n);
-    if (it == d.end())
-        d[n] = coef;
-}
-
 vec_basic UnivariatePolynomial::get_args() const
 {
     vec_basic args;
-    for (const auto &p : dict_) {
+    for (const auto &p : dict_.get_dict()) {
         if (p.first == 0)
             args.push_back(p.second.get_basic());
         else if (p.first == 1) {
@@ -494,8 +481,8 @@ vec_basic UnivariatePolynomial::get_args() const
 
 Expression UnivariatePolynomial::max_coef() const
 {
-    Expression curr = dict_.begin()->second;
-    for (const auto &it : dict_)
+    Expression curr = dict_.get_dict().begin()->second;
+    for (const auto &it : dict_.get_dict())
         if (curr.get_basic()->__cmp__(*it.second.get_basic()))
             curr = it.second;
     return curr;
@@ -504,7 +491,7 @@ Expression UnivariatePolynomial::max_coef() const
 Expression UnivariatePolynomial::eval(const Expression &x) const
 {
     Expression ans = 0;
-    for (const auto &p : dict_) {
+    for (const auto &p : dict_.get_dict()) {
         Expression temp;
         temp = pow_ex(x, Expression(p.first));
         ans += p.second * temp;
@@ -519,45 +506,44 @@ bool UnivariatePolynomial::is_zero() const
 
 bool UnivariatePolynomial::is_one() const
 {
-    return dict_.size() == 1 and dict_.begin()->second == 1
-           and dict_.begin()->first == 0;
+    return dict_.size() == 1 and dict_.get_dict().begin()->second == 1
+           and dict_.get_dict().begin()->first == 0;
 }
 
 bool UnivariatePolynomial::is_minus_one() const
 {
-    return dict_.size() == 1 and dict_.begin()->second == -1
-           and dict_.begin()->first == 0;
+    return dict_.size() == 1 and dict_.get_dict().begin()->second == -1
+           and dict_.get_dict().begin()->first == 0;
 }
 
 bool UnivariatePolynomial::is_integer() const
 {
     if (dict_.empty())
         return true;
-    return dict_.size() == 1 and dict_.begin()->first == 0;
+    return dict_.size() == 1 and dict_.get_dict().begin()->first == 0;
 }
 
 bool UnivariatePolynomial::is_symbol() const
 {
-    return dict_.size() == 1 and dict_.begin()->first == 1
-           and dict_.begin()->second == 1;
+    return dict_.size() == 1 and dict_.get_dict().begin()->first == 1
+           and dict_.get_dict().begin()->second == 1;
 }
 
 bool UnivariatePolynomial::is_mul() const
 {
-    return dict_.size() == 1 and dict_.begin()->first != 0
-           and dict_.begin()->second != 1 and dict_.begin()->second != 0;
+    return dict_.size() == 1 and dict_.get_dict().begin()->first != 0
+           and dict_.get_dict().begin()->second != 1 and dict_.get_dict().begin()->second != 0;
 }
 
 bool UnivariatePolynomial::is_pow() const
 {
-    return dict_.size() == 1 and dict_.begin()->second == 1
-           and dict_.begin()->first != 1 and dict_.begin()->first != 0;
+    return dict_.size() == 1 and dict_.get_dict().begin()->second == 1
+           and dict_.get_dict().begin()->first != 1 and dict_.get_dict().begin()->first != 0;
 }
 
 RCP<const UnivariatePolynomial> add_uni_poly(const UnivariatePolynomial &a,
                                              const UnivariatePolynomial &b)
 {
-    map_int_Expr dict;
     RCP<const Symbol> var = symbol("");
     if (a.get_var()->get_name() == "") {
         var = b.get_var();
@@ -568,25 +554,21 @@ RCP<const UnivariatePolynomial> add_uni_poly(const UnivariatePolynomial &a,
     } else {
         var = a.get_var();
     }
-    for (const auto &it : a.get_dict())
-        dict[it.first] = it.second;
-    for (const auto &it : b.get_dict())
-        dict[it.first] += it.second;
+    map_int_Expr dict;
+    dict = (a.get_dict2() + b.get_dict2()).get_dict();
     return univariate_polynomial(var, std::move(dict));
 }
 
 RCP<const UnivariatePolynomial> neg_uni_poly(const UnivariatePolynomial &a)
 {
     map_int_Expr dict;
-    for (const auto &it : a.get_dict())
-        dict[it.first] = -1 * it.second;
+    dict = (-a.get_dict2()).get_dict();
     return univariate_polynomial(a.get_var(), std::move(dict));
 }
 
 RCP<const UnivariatePolynomial> sub_uni_poly(const UnivariatePolynomial &a,
                                              const UnivariatePolynomial &b)
 {
-    map_int_Expr dict;
     RCP<const Symbol> var = symbol("");
     if (a.get_var()->get_name() == "") {
         var = b.get_var();
@@ -597,17 +579,14 @@ RCP<const UnivariatePolynomial> sub_uni_poly(const UnivariatePolynomial &a,
     } else {
         var = a.get_var();
     }
-    for (const auto &it : a.get_dict())
-        dict[it.first] = it.second;
-    for (const auto &it : b.get_dict())
-        dict[it.first] -= it.second;
+    map_int_Expr dict;
+    dict = (a.get_dict2() - b.get_dict2()).get_dict();
     return univariate_polynomial(var, std::move(dict));
 }
 
 RCP<const UnivariatePolynomial> mul_uni_poly(const UnivariatePolynomial &a,
                                              const UnivariatePolynomial &b)
 {
-    map_int_Expr dict;
     RCP<const Symbol> var = symbol("");
     if (a.get_var()->get_name() == "") {
         var = b.get_var();
@@ -618,13 +597,8 @@ RCP<const UnivariatePolynomial> mul_uni_poly(const UnivariatePolynomial &a,
     } else {
         var = a.get_var();
     }
-
-    if (a.get_dict().empty() and b.get_dict().empty())
-        return univariate_polynomial(var, {{0, 0}});
-
-    for (const auto &i1 : a.get_dict())
-        for (const auto &i2 : b.get_dict())
-            dict[i1.first + i2.first] += i1.second * i2.second;
+    map_int_Expr dict;
+    dict = (a.get_dict2() * b.get_dict2()).get_dict();
     return univariate_polynomial(var, std::move(dict));
 }
 

--- a/symengine/polynomial.h
+++ b/symengine/polynomial.h
@@ -119,12 +119,230 @@ univariate_int_polynomial(RCP<const Symbol> i, map_uint_mpz &&dict)
     return UnivariateIntPolynomial::from_dict(i, std::move(dict));
 }
 
+class UnivariateExprPolynomial
+{
+private:
+    //! Holds the dictionary for a UnivariatePolynomial
+    map_int_Expr dict_;
+
+public:
+    UnivariateExprPolynomial()
+    {
+    }
+    ~UnivariateExprPolynomial() SYMENGINE_NOEXCEPT
+    {
+    }
+    UnivariateExprPolynomial(const UnivariateExprPolynomial &) = default;
+    UnivariateExprPolynomial(UnivariateExprPolynomial &&other)
+        SYMENGINE_NOEXCEPT : dict_(std::move(other.dict_))
+    {
+    }
+    UnivariateExprPolynomial(int i)
+        : dict_({{0, Expression(i)}})
+    {
+    }
+    UnivariateExprPolynomial(map_int_Expr p)
+        : dict_(std::move(p))
+    {
+    }
+    UnivariateExprPolynomial(Expression expr)
+        : dict_({{0, expr}})
+    {
+    }
+
+    UnivariateExprPolynomial &operator=(const UnivariateExprPolynomial &)
+        = default;
+    UnivariateExprPolynomial &
+    operator=(UnivariateExprPolynomial &&other) SYMENGINE_NOEXCEPT
+    {
+        if (this != &other)
+            this->dict_ = std::move(other.dict_);
+        return *this;
+
+    }
+
+    friend std::ostream &operator<<(std::ostream &os,
+                                    const UnivariateExprPolynomial &expr)
+    {
+        os << expr.dict_;
+        return os;
+    }
+
+    friend UnivariateExprPolynomial operator+(const UnivariateExprPolynomial &a,
+                                              const UnivariateExprPolynomial &b)
+    {
+        map_int_Expr dict;
+        for (const auto &it : a.dict_)
+            dict[it.first] = it.second;
+        for (const auto &it : b.dict_)
+            dict[it.first] += it.second;
+        return UnivariateExprPolynomial(dict);
+    }
+
+    UnivariateExprPolynomial &operator+=(const UnivariateExprPolynomial &other)
+    {
+        for(auto &it : other.dict_)
+            dict_[it.first] += it.second;
+        return *this;
+    }
+
+    friend UnivariateExprPolynomial operator-(const UnivariateExprPolynomial &a,
+                                              const UnivariateExprPolynomial &b)
+    {
+        map_int_Expr dict;
+        for (const auto &it : a.dict_)
+            dict[it.first] = it.second;
+        for (const auto &it : b.dict_)
+            dict[it.first] -= it.second;
+        return UnivariateExprPolynomial(dict);
+    }
+
+    UnivariateExprPolynomial operator-() const
+    {
+        map_int_Expr dict;
+        for (auto &it : dict_)
+            dict[it.first] = -it.second;
+        return UnivariateExprPolynomial(dict);
+    }
+
+    UnivariateExprPolynomial &operator-=(const UnivariateExprPolynomial &other)
+    {
+        for(auto &it : other.dict_)
+            dict_[it.first] -= it.second;
+        return *this;
+    }
+
+    friend UnivariateExprPolynomial operator*(const UnivariateExprPolynomial &a,
+                                              const UnivariateExprPolynomial &b)
+    {
+        if (a.dict_.empty() or b.dict_.empty())
+            return UnivariateExprPolynomial({{0, Expression(0)}});
+
+        map_int_Expr dict;
+        for (const auto &i1 : a.dict_)
+            for (const auto &i2 : b.dict_)
+                dict[i1.first + i2.first] += i1.second * i2.second;
+
+        return UnivariateExprPolynomial(dict);
+    }
+
+    friend UnivariateExprPolynomial operator/(const UnivariateExprPolynomial &a,
+                                              const Expression &b)
+    {
+        return UnivariateExprPolynomial(a * (1/b));
+    }
+
+    UnivariateExprPolynomial &operator*=(const UnivariateExprPolynomial &other)
+    {
+        if (dict_.empty())
+            return *this;
+
+        for(const auto &i1 : dict_)
+            for (const auto &i2 : other.dict_)
+                dict_[i1.first + i2.first] += i1.second * i2.second;
+
+        return *this;
+    }
+
+    UnivariateExprPolynomial &operator/=(const Expression &other)
+    {
+        dict_ = (UnivariateExprPolynomial(dict_) * UnivariateExprPolynomial(1/other)).dict_;
+        return *this;
+    }
+
+    bool operator==(const UnivariateExprPolynomial &other) const
+    {
+        return map_int_Expr_compare(dict_, other.dict_);
+    }
+
+    bool operator==(int i) const
+    {
+        return map_int_Expr_compare(dict_, UnivariateExprPolynomial(i).dict_);
+    }
+
+    bool operator!=(const UnivariateExprPolynomial &other) const
+    {
+        return not(*this == other);
+    }
+
+    /*!
+    * Adds coef*var_**n to the dict_
+    */
+    UnivariateExprPolynomial &dict_add_term(const Expression &coef, const int &n)
+    {
+        auto it = dict_.find(n);
+        if (it == dict_.end())
+            dict_[n] = coef;
+        return *this;
+    }
+
+    //! Method to get UnivariatePolynomial's dictionary
+    const map_int_Expr &get_dict() const
+    {
+        return dict_;
+    }
+
+    int size() const
+    {
+        return dict_.size();
+    }
+
+    bool empty() const
+    {
+        return dict_.empty();
+    }
+
+    std::size_t __hash__() const
+    {
+        std::size_t seed = UNIVARIATEPOLYNOMIAL;
+        for (const auto &it : dict_) {
+            std::size_t temp = UNIVARIATEPOLYNOMIAL;
+            hash_combine<unsigned int>(temp, it.first);
+            hash_combine<Basic>(temp, *(it.second.get_basic()));
+            seed += temp;
+        }
+        return seed;
+    }
+
+    // const RCP<const Basic> get_basic() const
+    // {
+    //     RCP<const Symbol> x = poly_->get_var();
+    //     umap_basic_num dict_;
+    //     RCP<const Number> coeff;
+    //     for (const auto &it : poly_->get_dict()) {
+    //         if (it.first != 0) {
+    //             auto term = mul(
+    //                 it.second.get_basic(),
+    //                 pow_ex(Expression(x), Expression(it.first)).get_basic());
+    //             RCP<const Number> coef;
+    //             coef = zero;
+    //             Add::coef_dict_add_term(outArg((coef)), dict_, one, term);
+    //         } else
+    //             coeff = rcp_static_cast<const Number>(it.second.get_basic());
+    //     }
+    //     return Add::from_dict(coeff, std::move(dict_));
+    // }
+
+    int compare(const UnivariateExprPolynomial &other)
+    {
+        return map_int_Expr_compare(dict_, other.dict_);
+    }
+
+    Expression find_cf(int deg) const
+    {
+        if(dict_.find(deg) != dict_.end())
+            return dict_.at(deg);
+        else
+            return Expression(0);
+    }
+}; // UnivariateExprPolynomial
+
 class UnivariatePolynomial : public Basic
 {
 private:
     int degree_;
     RCP<const Symbol> var_;
-    map_int_Expr dict_;
+    UnivariateExprPolynomial dict_;
 
 public:
     IMPLEMENT_TYPEID(UNIVARIATEPOLYNOMIAL)
@@ -141,7 +359,7 @@ public:
         return UnivariatePolynomial::from_vec(var, v);
     }
 
-    bool is_canonical(const int &degree, const map_int_Expr &dict) const;
+    bool is_canonical(const int &degree, const UnivariateExprPolynomial &dict) const;
     std::size_t __hash__() const;
     bool __eq__(const Basic &o) const;
     int compare(const Basic &o) const;
@@ -153,11 +371,7 @@ public:
     from_dict(const RCP<const Symbol> &var, map_int_Expr &&d);
     static RCP<const UnivariatePolynomial>
     from_vec(const RCP<const Symbol> &var, const std::vector<Expression> &v);
-    /*!
-    * Adds coef*var_**n to the dict_
-    */
-    static void dict_add_term(map_int_Expr &d, const Expression &coef,
-                              const int &n);
+    
     Expression max_coef() const;
     //! Evaluates the UnivariatePolynomial at value x
     Expression eval(const Expression &x) const;
@@ -189,8 +403,13 @@ public:
     }
     inline const map_int_Expr &get_dict() const
     {
+        return dict_.get_dict();
+    }
+    const UnivariateExprPolynomial &get_dict2() const
+    {
         return dict_;
     }
+
 }; // UnivariatePolynomial
 
 //! Adding two UnivariatePolynomial a and b
@@ -210,184 +429,6 @@ univariate_polynomial(RCP<const Symbol> i, map_int_Expr &&dict)
 {
     return UnivariatePolynomial::from_dict(i, std::move(dict));
 }
-
-class UnivariateExprPolynomial
-{
-private:
-    RCP<const UnivariatePolynomial> poly_;
-
-public:
-//! Construct UnivariateExprPolynomial from UnivariatePolynomial
-#if defined(HAVE_SYMENGINE_IS_CONSTRUCTIBLE)
-    template <
-        typename T,
-        typename = typename std::
-            enable_if<std::is_constructible<RCP<const UnivariatePolynomial>,
-                                            T &&>::value>::type>
-#else
-    template <typename T>
-#endif
-    UnivariateExprPolynomial(T &&o)
-        : poly_(std::forward<T>(o))
-    {
-    }
-    UnivariateExprPolynomial()
-    {
-    }
-    ~UnivariateExprPolynomial() SYMENGINE_NOEXCEPT
-    {
-    }
-    UnivariateExprPolynomial(const UnivariateExprPolynomial &) = default;
-    UnivariateExprPolynomial(UnivariateExprPolynomial &&other)
-        SYMENGINE_NOEXCEPT : poly_(std::move(other.poly_))
-    {
-    }
-    UnivariateExprPolynomial(int i)
-        : poly_(UnivariatePolynomial::create(symbol(""), {Expression(i)}))
-    {
-    }
-    UnivariateExprPolynomial(std::string varname)
-        : poly_(UnivariatePolynomial::create(symbol(varname), {0, 1}))
-    {
-    }
-    UnivariateExprPolynomial(RCP<const UnivariatePolynomial> p)
-        : poly_(std::move(p))
-    {
-    }
-    UnivariateExprPolynomial(Expression expr)
-        : poly_(UnivariatePolynomial::create(symbol(""), {expr}))
-    {
-    }
-    UnivariateExprPolynomial &operator=(const UnivariateExprPolynomial &)
-        = default;
-    UnivariateExprPolynomial &
-    operator=(UnivariateExprPolynomial &&other) SYMENGINE_NOEXCEPT
-    {
-        if (this != &other)
-            this->poly_ = std::move(other.poly_);
-        return *this;
-    }
-
-    friend std::ostream &operator<<(std::ostream &os,
-                                    const UnivariateExprPolynomial &expr)
-    {
-        os << expr.poly_->__str__();
-        return os;
-    }
-
-    friend UnivariateExprPolynomial operator+(const UnivariateExprPolynomial &a,
-                                              const UnivariateExprPolynomial &b)
-    {
-        return UnivariateExprPolynomial(add_uni_poly(*a.poly_, *b.poly_));
-    }
-
-    UnivariateExprPolynomial &operator+=(const UnivariateExprPolynomial &other)
-    {
-        poly_ = add_uni_poly(*poly_, *other.poly_);
-        return *this;
-    }
-
-    friend UnivariateExprPolynomial operator-(const UnivariateExprPolynomial &a,
-                                              const UnivariateExprPolynomial &b)
-    {
-        return UnivariateExprPolynomial(sub_uni_poly(*a.poly_, *b.poly_));
-    }
-
-    UnivariateExprPolynomial operator-() const
-    {
-        return neg_uni_poly(*this->poly_);
-    }
-
-    UnivariateExprPolynomial &operator-=(const UnivariateExprPolynomial &other)
-    {
-        poly_ = sub_uni_poly(*poly_, *other.poly_);
-        return *this;
-    }
-
-    friend UnivariateExprPolynomial operator*(const UnivariateExprPolynomial &a,
-                                              const UnivariateExprPolynomial &b)
-    {
-        return UnivariateExprPolynomial(mul_uni_poly(*a.poly_, *b.poly_));
-    }
-
-    friend UnivariateExprPolynomial operator/(const UnivariateExprPolynomial &a,
-                                              const Expression &b)
-    {
-        return UnivariateExprPolynomial(
-            mul_uni_poly(*a.poly_, *UnivariateExprPolynomial(1 / b).poly_));
-    }
-
-    UnivariateExprPolynomial &operator*=(const UnivariateExprPolynomial &other)
-    {
-        poly_ = mul_uni_poly(*poly_, *other.poly_);
-        return *this;
-    }
-
-    UnivariateExprPolynomial &operator/=(const Expression &other)
-    {
-        poly_ = mul_uni_poly(*poly_, *UnivariateExprPolynomial(1 / other).poly_);
-        return *this;
-    }
-
-    bool operator==(const UnivariateExprPolynomial &other) const
-    {
-        return eq(*poly_, *other.poly_);
-    }
-
-    bool operator==(int i) const
-    {
-        return eq(*poly_, *(UnivariateExprPolynomial(i).poly_));
-    }
-
-    bool operator!=(const UnivariateExprPolynomial &other) const
-    {
-        return not(*this == other);
-    }
-
-    //! Method to get UnivariatePolynomial from UnivariateExprPolynomial
-    const RCP<const UnivariatePolynomial> &get_univariate_poly() const
-    {
-        return poly_;
-    }
-
-    std::size_t __hash__() const
-    {
-        return poly_->hash();
-    }
-
-    const RCP<const Basic> get_basic() const
-    {
-        RCP<const Symbol> x = poly_->get_var();
-        umap_basic_num dict_;
-        RCP<const Number> coeff;
-        for (const auto &it : poly_->get_dict()) {
-            if (it.first != 0) {
-                auto term = mul(
-                    it.second.get_basic(),
-                    pow_ex(Expression(x), Expression(it.first)).get_basic());
-                RCP<const Number> coef;
-                coef = zero;
-                Add::coef_dict_add_term(outArg((coef)), dict_, one, term);
-            } else
-                coeff = rcp_static_cast<const Number>(it.second.get_basic());
-        }
-        return Add::from_dict(coeff, std::move(dict_));
-    }
-
-    int compare(const UnivariateExprPolynomial &other)
-    {
-        return poly_->compare(*other.poly_);
-    }
-
-    Expression find_cf(int deg) const
-    {
-        if (poly_->get_dict().find(deg) != poly_->get_dict().end()) {
-            return poly_->get_dict().at(deg);
-        } else {
-            return Expression(0);
-        }
-    }
-}; // UnivariateExprPolynomial
 
 } // SymEngine
 

--- a/symengine/series_generic.cpp
+++ b/symengine/series_generic.cpp
@@ -14,7 +14,7 @@ RCP<const UnivariateSeries> UnivariateSeries::series(const RCP<const Basic> &t,
                                                      const std::string &x,
                                                      unsigned int prec)
 {
-    UnivariateExprPolynomial p(UnivariatePolynomial::create(symbol(x), {0, 1}));
+    UnivariateExprPolynomial p({{1, Expression(1)}});
     SeriesVisitor<UnivariateExprPolynomial, Expression, UnivariateSeries>
         visitor(std::move(p), x, prec);
     return visitor.series(t);
@@ -22,26 +22,30 @@ RCP<const UnivariateSeries> UnivariateSeries::series(const RCP<const Basic> &t,
 
 std::size_t UnivariateSeries::__hash__() const
 {
-    return p_.get_univariate_poly()->hash()
+    return p_.__hash__()
            + std::size_t(get_degree() * 84728863L);
 }
 
 int UnivariateSeries::compare(const Basic &other) const
 {
-    SYMENGINE_ASSERT(is_a<UnivariateSeries>(other))
-    const UnivariateSeries &o = static_cast<const UnivariateSeries &>(other);
-    return p_.get_basic()->__cmp__(*o.p_.get_basic());
+    // SYMENGINE_ASSERT(is_a<UnivariateSeries>(other))
+    // const UnivariateSeries &o = static_cast<const UnivariateSeries &>(other);
+    // return p_.get_basic()->__cmp__(*o.p_.get_basic());
+    throw std::runtime_error("Not implemented");
 }
 
 RCP<const Basic> UnivariateSeries::as_basic() const
 {
-    return p_.get_basic();
+    // return univariate_polynomial()
+    throw std::runtime_error("Not implemented");
+    // return p_.get_basic();
 }
 
 umap_int_basic UnivariateSeries::as_dict() const
 {
     umap_int_basic map;
-    for (const auto &it : p_.get_univariate_poly()->get_dict())
+    // for (const auto &it : p_.get_univariate_poly()->get_dict())
+    for (const auto &it : p_.get_dict())
         if (it.second != 0)
             map[it.first] = it.second.get_basic();
     return map;
@@ -49,16 +53,15 @@ umap_int_basic UnivariateSeries::as_dict() const
 
 RCP<const Basic> UnivariateSeries::get_coeff(int deg) const
 {
-    if (p_.get_univariate_poly()->get_dict().count(deg) == 0)
+    if (p_.get_dict().count(deg) == 0)
         return zero;
     else
-        return p_.get_univariate_poly()->get_dict().at(deg).get_basic();
+        return p_.get_dict().at(deg).get_basic();
 }
 
 UnivariateExprPolynomial UnivariateSeries::var(const std::string &s)
 {
-    return UnivariateExprPolynomial(
-        UnivariatePolynomial::create(symbol(s), {0, 1}));
+    return UnivariateExprPolynomial({{1, Expression(1)}});
 }
 
 Expression UnivariateSeries::convert(const Basic &x)
@@ -68,7 +71,7 @@ Expression UnivariateSeries::convert(const Basic &x)
 
 int UnivariateSeries::ldegree(const UnivariateExprPolynomial &s)
 {
-    return s.get_univariate_poly()->get_dict().begin()->first;
+    return s.get_dict().begin()->first;
 }
 
 UnivariateExprPolynomial
@@ -76,8 +79,8 @@ UnivariateSeries::mul(const UnivariateExprPolynomial &a,
                       const UnivariateExprPolynomial &b, unsigned prec)
 {
     map_int_Expr p;
-    for (auto &it1 : a.get_univariate_poly()->get_dict()) {
-        for (auto &it2 : b.get_univariate_poly()->get_dict()) {
+    for (auto &it1 : a.get_dict()) {
+        for (auto &it2 : b.get_dict()) {
             int exp = it1.first + it2.first;
             if (exp < (int)prec) {
                 p[exp] += it1.second * it2.second;
@@ -86,12 +89,13 @@ UnivariateSeries::mul(const UnivariateExprPolynomial &a,
             }
         }
     }
-    if (a.get_univariate_poly()->get_var()->get_name() == "")
-        return UnivariateExprPolynomial(UnivariatePolynomial::from_dict(
-            b.get_univariate_poly()->get_var(), std::move(p)));
-    else
-        return UnivariateExprPolynomial(UnivariatePolynomial::from_dict(
-            a.get_univariate_poly()->get_var(), std::move(p)));
+    return UnivariateExprPolynomial(p);
+    // if (a.get_univariate_poly()->get_var()->get_name() == "")
+    //     return UnivariateExprPolynomial(UnivariatePolynomial::from_dict(
+    //         b.get_univariate_poly()->get_var(), std::move(p)));
+    // else
+    //     return UnivariateExprPolynomial(UnivariatePolynomial::from_dict(
+    //         a.get_univariate_poly()->get_var(), std::move(p)));
 }
 
 UnivariateExprPolynomial
@@ -99,12 +103,11 @@ UnivariateSeries::pow(const UnivariateExprPolynomial &base, int exp,
                       unsigned prec)
 {
     if (exp < 0) {
-        SYMENGINE_ASSERT(base.get_univariate_poly()->get_dict().size() == 1)
+        SYMENGINE_ASSERT(base.size() == 1)
         map_int_Expr dict;
-        dict[-(base.get_univariate_poly()->get_dict().begin()->first)]
-            = 1 / base.get_univariate_poly()->get_dict().begin()->second;
-        return pow(UnivariateExprPolynomial(univariate_polynomial(
-                       base.get_univariate_poly()->get_var(), std::move(dict))),
+        dict[-(base.get_dict().begin()->first)]
+            = 1 / base.get_dict().begin()->second;
+        return pow(UnivariateExprPolynomial(std::move(dict)),
                    -exp, prec);
     }
     if (exp == 0) {
@@ -134,10 +137,10 @@ Expression UnivariateSeries::find_cf(const UnivariateExprPolynomial &s,
                                      const UnivariateExprPolynomial &var,
                                      int deg)
 {
-    if (s.get_univariate_poly()->get_dict().count(deg) == 0)
+    if (s.get_dict().count(deg) == 0)
         return Expression(0);
     else
-        return (s.get_univariate_poly()->get_dict()).at(deg);
+        return (s.get_dict()).at(deg);
 }
 
 Expression UnivariateSeries::root(Expression &c, unsigned n)
@@ -149,13 +152,18 @@ UnivariateExprPolynomial
 UnivariateSeries::diff(const UnivariateExprPolynomial &s,
                        const UnivariateExprPolynomial &var)
 {
-    RCP<const Basic> p
-        = s.get_univariate_poly()->diff(var.get_univariate_poly()->get_var());
-    if (is_a<const UnivariatePolynomial>(*p))
-        return UnivariateExprPolynomial(
-            rcp_static_cast<const UnivariatePolynomial>(p));
-    else
-        throw std::runtime_error("Not a UnivariatePolynomial");
+    // RCP<const Basic> p
+    //     = s.get_univariate_poly()->diff(var.get_univariate_poly()->get_var());
+    // if (is_a<const UnivariatePolynomial>(*p))
+    //     return UnivariateExprPolynomial(
+    //         rcp_static_cast<const UnivariatePolynomial>(p));
+    // else
+    //     throw std::runtime_error("Not a UnivariatePolynomial");
+    throw std::runtime_error("Not implemented");
+    // map_int_Expr p;
+    // for (auto &i : s.get_dict())
+    //     p[i.first-1] = i.second.get_basic()->diff(symbol(get_var()));
+    // return UnivariateExprPolynomial(p);
 }
 
 UnivariateExprPolynomial
@@ -163,7 +171,7 @@ UnivariateSeries::integrate(const UnivariateExprPolynomial &s,
                             const UnivariateExprPolynomial &var)
 {
     map_int_Expr dict;
-    for (auto &it : s.get_univariate_poly()->get_dict()) {
+    for (auto &it : s.get_dict()) {
         if (it.first != -1) {
             dict.insert(std::pair<int, Expression>(it.first + 1,
                                                    it.second / (it.first + 1)));
@@ -171,8 +179,10 @@ UnivariateSeries::integrate(const UnivariateExprPolynomial &s,
             throw std::runtime_error("Not Implemented");
         }
     }
-    return UnivariateExprPolynomial(univariate_polynomial(
-        var.get_univariate_poly()->get_var(), std::move(dict)));
+    // return UnivariateExprPolynomial(univariate_polynomial(
+    //     var.get_univariate_poly()->get_var(), std::move(dict)));
+
+    return UnivariateExprPolynomial(dict);
 }
 
 UnivariateExprPolynomial
@@ -180,10 +190,12 @@ UnivariateSeries::subs(const UnivariateExprPolynomial &s,
                        const UnivariateExprPolynomial &var,
                        const UnivariateExprPolynomial &r, unsigned prec)
 {
-    UnivariateExprPolynomial result(
-        r.get_univariate_poly()->get_var()->get_name());
-    for (auto &i : s.get_univariate_poly()->get_dict())
+    UnivariateExprPolynomial result({{1, Expression(1)}});
+        // r.get_univariate_poly()->get_var()->get_name());
+
+    for (auto &i : s.get_dict())
         result += i.second * pow(r, i.first, prec);
+
     return result;
 }
 


### PR DESCRIPTION
UnivariateExprPolynomial contains map_int_Expr dict and UnivariatePolynomial contains UnivariateExprPolynomial. The end goal of this is to make Expression polynomial operations faster.

Changes so far include: rearrange UnivariateExprPolynomial to be before UnivariatePolynomial; move dict_add_term to UnivariateExprPolynomial; hash for dictionary moved to UnivariateExprPolynomial; arithmetic operations in UnivariatePolynomial moved to overloaded operators in UnivariateExprPolynomial.

This works with the current polynomial tests. Incorporation of the new UnivariateExprPolynomial isn't complete as of yet.
