### PR TITLE
Preparations for Fast Series Expansion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ symengine/tests/eval/test_lambda_double
 symengine/tests/expression/test_expression
 symengine/tests/basic/test_series_expansion_UP
 symengine/tests/basic/test_series_expansion_URatP
+symengine/tests/basic/test_series_expansion_URatF
 
 # Benchmarks executables
 benchmarks/add1
@@ -104,6 +105,7 @@ benchmarks/expand7
 benchmarks/expand7_ginac
 benchmarks/series_expansion_sincos_piranha
 benchmarks/series_expansion_sinp
+benchmarks/series_expansion_sincos_flint
 
 #rubygem
 symengine/ruby/Gemfile.lock

--- a/benchmarks/series.cpp
+++ b/benchmarks/series.cpp
@@ -15,29 +15,145 @@ using SymEngine::rcp_dynamic_cast;
 using SymEngine::Expression;
 using SymEngine::UnivariatePolynomial;
 using SymEngine::UnivariateExprPolynomial;
+using SymEngine::map_int_Expr;
+using SymEngine::pow;
 
 int main(int argc, char *argv[])
 {
     SymEngine::print_stack_on_segfault();
 
     RCP<const Symbol> x = symbol("x");
-    std::vector<Expression> v;
-    int N;
-
-    N = 1000;
+    // std::vector<Expression> v, v2;
+    map_int_Expr p, q;
+    int N = 100000;
+    int N2 = 1000;
     for (int i = 0; i < N; ++i) {
-        Expression coef(i);
-        v.push_back(coef);
+        // Expression coef(i);
+        Expression coef(pow(x, integer(i)));
+        // v.push_back(coef);
+        p[i] = coef;
+    }
+    for (int j = 0; j < N2; ++j) {
+        // Expression coef(j);
+        Expression coef(pow(x, integer(j)));
+        // v2.push_back(coef);
+        q[j] = coef;
     }
 
-    UnivariateExprPolynomial c, p(UnivariatePolynomial::create(x, v));
+    // UnivariateExprPolynomial c, p(UnivariatePolynomial::create(x, v));
+    UnivariateExprPolynomial c, d, a, b, f, g, s, r, t, u, n, ep(p), epq(q);
+    UnivariateExprPolynomial e({{0, Expression(7)}});
+    Expression coeff(7);
+
+    // ep += ep
+    c = ep;
     auto t1 = std::chrono::high_resolution_clock::now();
-    c = UnivariateSeries::mul(p, p, 1000);
+    c += ep;
+    // d = UnivariateSeries::mul(ep, ep, 1000);
     auto t2 = std::chrono::high_resolution_clock::now();
-    // std::cout << *a << std::endl;
-    std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
+    std::cout << "ep += ep "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
                      .count()
               << "ms" << std::endl;
+
+    // ep + ep
+    t1 = std::chrono::high_resolution_clock::now();
+    d = ep + ep;
+    t2 = std::chrono::high_resolution_clock::now();
+    std::cout << "ep + ep "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
+                     .count()
+              << "ms" << std::endl;
+
+    // ep -= ep
+    t = ep;
+    t1 = std::chrono::high_resolution_clock::now();
+    t -= ep;
+    // d = UnivariateSeries::mul(ep, ep, 1000);
+    t2 = std::chrono::high_resolution_clock::now();
+    std::cout << "ep -= ep "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
+                     .count()
+              << "ms" << std::endl;
+
+    // ep - ep
+    t1 = std::chrono::high_resolution_clock::now();
+    u = ep - ep;
+    t2 = std::chrono::high_resolution_clock::now();
+    std::cout << "ep - ep "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
+                     .count()
+              << "ms" << std::endl;
+
+    // -ep
+    t1 = std::chrono::high_resolution_clock::now();
+    n = -ep;
+    t2 = std::chrono::high_resolution_clock::now();
+    std::cout << "-ep "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
+                     .count()
+              << "ms" << std::endl;
+
+    // epq * epq
+    t1 = std::chrono::high_resolution_clock::now();
+    b = epq * epq;
+    t2 = std::chrono::high_resolution_clock::now();
+    std::cout << "epq * epq "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
+                     .count()
+              << "ms" << std::endl;
+
+    // epq *= epq
+    r = epq;
+    t1 = std::chrono::high_resolution_clock::now();
+    r *= epq;
+    t2 = std::chrono::high_resolution_clock::now();
+    std::cout << "epq *= epq "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
+                     .count()
+              << "ms" << std::endl;
+
+    // ep * e single constant
+    t1 = std::chrono::high_resolution_clock::now();
+    s = ep * e;
+    t2 = std::chrono::high_resolution_clock::now();
+    std::cout << "ep * e single constant "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
+                     .count()
+              << "ms" << std::endl;
+
+    // ep *= e single constant
+    a = ep;
+    t1 = std::chrono::high_resolution_clock::now();
+    a *= e;
+    t2 = std::chrono::high_resolution_clock::now();
+    std::cout << "ep *= e single constant "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
+                     .count()
+              << "ms" << std::endl;
+
+    // ep / coeff
+    t1 = std::chrono::high_resolution_clock::now();
+    f = a / coeff;
+    t2 = std::chrono::high_resolution_clock::now();
+    std::cout << "ep / coeff "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
+                     .count()
+              << "ms" << std::endl;
+    // std::cout << f.get_dict().at(0) << " + " << f.get_dict().at(1) << " + "
+    // << f.get_dict().at(2) << std::endl;
+
+    // ep /= coeff
+    g = a;
+    t1 = std::chrono::high_resolution_clock::now();
+    g /= coeff;
+    t2 = std::chrono::high_resolution_clock::now();
+    std::cout << "ep /= coeff "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
+                     .count()
+              << "ms" << std::endl;
+    // std::cout << g.get_dict().at(0) << " + " << g.get_dict().at(1) << " + "
+    // << g.get_dict().at(2) << std::endl;
 
     return 0;
 }

--- a/symengine/dict.cpp
+++ b/symengine/dict.cpp
@@ -92,6 +92,11 @@ std::ostream &operator<<(std::ostream &out, const SymEngine::set_basic &d)
     return SymEngine::print_vec_rcp(out, d);
 }
 
+std::ostream &operator<<(std::ostream &out, const SymEngine::map_int_Expr &d)
+{
+    return SymEngine::print_map(out, d);
+}
+
 bool vec_basic_eq(const vec_basic &a, const vec_basic &b)
 {
     // Can't be equal if # of entries differ:

--- a/symengine/dict.h
+++ b/symengine/dict.h
@@ -156,6 +156,7 @@ std::ostream &operator<<(std::ostream &out,
                          const SymEngine::umap_basic_basic &d);
 std::ostream &operator<<(std::ostream &out, const SymEngine::vec_basic &d);
 std::ostream &operator<<(std::ostream &out, const SymEngine::set_basic &d);
+std::ostream &operator<<(std::ostream &out, const SymEngine::map_int_Expr &d);
 
 } // SymEngine
 

--- a/symengine/expand.cpp
+++ b/symengine/expand.cpp
@@ -286,10 +286,10 @@ public:
             = univariate_polynomial(x->get_var(), {{0, 1}});
         while (i != 0) {
             if (i % 2 == 1) {
-                r = mul_uni_poly(r, x);
+                r = mul_uni_poly(*r, *x);
                 i--;
             }
-            x = mul_uni_poly(x, x);
+            x = mul_uni_poly(*x, *x);
             i /= 2;
         }
         _coef_dict_add_term(multiply, r);

--- a/symengine/polynomial.h
+++ b/symengine/polynomial.h
@@ -119,12 +119,246 @@ univariate_int_polynomial(RCP<const Symbol> i, map_uint_mpz &&dict)
     return UnivariateIntPolynomial::from_dict(i, std::move(dict));
 }
 
+class UnivariateExprPolynomial
+{
+private:
+    //! Holds the dictionary for a UnivariatePolynomial
+    map_int_Expr dict_;
+
+public:
+    UnivariateExprPolynomial()
+    {
+    }
+    ~UnivariateExprPolynomial() SYMENGINE_NOEXCEPT
+    {
+    }
+    UnivariateExprPolynomial(const UnivariateExprPolynomial &) = default;
+    UnivariateExprPolynomial(UnivariateExprPolynomial &&other)
+        SYMENGINE_NOEXCEPT : dict_(std::move(other.dict_))
+    {
+    }
+    UnivariateExprPolynomial(const int &i)
+    {
+        if (i != 0)
+            dict_ = {{0, Expression(i)}};
+    }
+    UnivariateExprPolynomial(const std::string &s) : dict_({{1, Expression(1)}})
+    {
+    }
+    UnivariateExprPolynomial(const map_int_Expr &p)
+    {
+        dict_ = p;
+        auto iter = dict_.begin();
+        while (iter != dict_.end()) {
+            if (Expression(0) == iter->second) {
+                auto toErase = iter;
+                iter++;
+                dict_.erase(toErase);
+            } else
+                iter++;
+        }
+    }
+    UnivariateExprPolynomial(const Expression &expr)
+    {
+        if (expr != Expression(0))
+            dict_ = {{0, std::move(expr)}};
+    }
+
+    UnivariateExprPolynomial &operator=(const UnivariateExprPolynomial &)
+        = default;
+    UnivariateExprPolynomial &
+    operator=(UnivariateExprPolynomial &&other) SYMENGINE_NOEXCEPT
+    {
+        if (this != &other)
+            this->dict_ = std::move(other.dict_);
+        return *this;
+    }
+
+    friend std::ostream &operator<<(std::ostream &os,
+                                    const UnivariateExprPolynomial &expr)
+    {
+        os << expr.dict_;
+        return os;
+    }
+
+    friend UnivariateExprPolynomial operator+(const UnivariateExprPolynomial &a,
+                                              const UnivariateExprPolynomial &b)
+    {
+        map_int_Expr dict;
+        for (const auto &it : a.dict_)
+            dict[it.first] = it.second;
+        for (const auto &it : b.dict_)
+            dict[it.first] += it.second;
+        return UnivariateExprPolynomial(dict);
+    }
+
+    UnivariateExprPolynomial &operator+=(const UnivariateExprPolynomial &other)
+    {
+        for (auto &it : other.dict_)
+            dict_[it.first] += it.second;
+        return *this;
+    }
+
+    friend UnivariateExprPolynomial operator-(const UnivariateExprPolynomial &a,
+                                              const UnivariateExprPolynomial &b)
+    {
+        map_int_Expr dict;
+        for (const auto &it : a.dict_)
+            dict[it.first] = it.second;
+        for (const auto &it : b.dict_)
+            dict[it.first] -= it.second;
+        return UnivariateExprPolynomial(dict);
+    }
+
+    UnivariateExprPolynomial operator-() const
+    {
+        map_int_Expr dict;
+        for (auto &it : dict_)
+            dict[it.first] = -it.second;
+        return UnivariateExprPolynomial(dict);
+    }
+
+    UnivariateExprPolynomial &operator-=(const UnivariateExprPolynomial &other)
+    {
+        for (auto &it : other.dict_)
+            dict_[it.first] -= it.second;
+        return *this;
+    }
+
+    friend UnivariateExprPolynomial operator*(const UnivariateExprPolynomial &a,
+                                              const UnivariateExprPolynomial &b)
+    {
+        if (a.dict_.empty() or b.dict_.empty())
+            return UnivariateExprPolynomial({{0, Expression(0)}});
+
+        map_int_Expr dict;
+        for (const auto &i1 : a.dict_)
+            for (const auto &i2 : b.dict_)
+                dict[i1.first + i2.first] += i1.second * i2.second;
+
+        return UnivariateExprPolynomial(dict);
+    }
+
+    friend UnivariateExprPolynomial operator/(const UnivariateExprPolynomial &a,
+                                              const Expression &b)
+    {
+        return UnivariateExprPolynomial(a * (1 / b));
+    }
+
+    UnivariateExprPolynomial &operator*=(const UnivariateExprPolynomial &other)
+    {
+        if (dict_.empty())
+            return *this;
+
+        //! other is a just constant term
+        if (other.dict_.size() == 1
+            and other.dict_.find(0) != other.dict_.end()) {
+            for (const auto &i1 : dict_)
+                for (const auto &i2 : other.dict_)
+                    dict_[i1.first + i2.first] = i1.second * i2.second;
+            return *this;
+        }
+
+        map_int_Expr p;
+        for (const auto &i1 : dict_)
+            for (const auto &i2 : other.dict_)
+                p[i1.first + i2.first] += i1.second * i2.second;
+        *this = UnivariateExprPolynomial(p);
+        return *this;
+    }
+
+    UnivariateExprPolynomial &operator/=(const Expression &other)
+    {
+        dict_ = (UnivariateExprPolynomial(dict_)
+                 * UnivariateExprPolynomial(1 / other))
+                    .dict_;
+        return *this;
+    }
+
+    bool operator==(const UnivariateExprPolynomial &other) const
+    {
+        return map_int_Expr_compare(dict_, other.dict_) == 0;
+    }
+
+    bool operator==(int i) const
+    {
+        return map_int_Expr_compare(dict_, UnivariateExprPolynomial(i).dict_)
+               == 0;
+    }
+
+    bool operator!=(const UnivariateExprPolynomial &other) const
+    {
+        return not(*this == other) != 0;
+    }
+
+    /*!
+    * Adds coef*var_**n to the dict_
+    */
+    void dict_add_term(const Expression &coef, const int &n)
+    {
+        auto it = dict_.find(n);
+        if (it == dict_.end())
+            dict_[n] = coef;
+        // return *this;
+    }
+
+    //! Method to get UnivariatePolynomial's dictionary
+    const map_int_Expr &get_dict() const
+    {
+        return dict_;
+    }
+
+    int size() const
+    {
+        return dict_.size();
+    }
+
+    bool empty() const
+    {
+        return dict_.empty();
+    }
+
+    std::size_t __hash__() const
+    {
+        std::size_t seed = UNIVARIATEPOLYNOMIAL;
+        for (const auto &it : dict_) {
+            std::size_t temp = UNIVARIATEPOLYNOMIAL;
+            hash_combine<unsigned int>(temp, it.first);
+            hash_combine<Basic>(temp, *(it.second.get_basic()));
+            seed += temp;
+        }
+        return seed;
+    }
+
+    const umap_int_basic get_basic() const
+    {
+        umap_int_basic p;
+        for (const auto &it : dict_)
+            if (it.second != 0)
+                p[it.first] = it.second.get_basic();
+        return p;
+    }
+
+    int compare(const UnivariateExprPolynomial &other)
+    {
+        return map_int_Expr_compare(dict_, other.dict_);
+    }
+
+    Expression find_cf(int deg) const
+    {
+        if (dict_.find(deg) != dict_.end())
+            return dict_.at(deg);
+        else
+            return Expression(0);
+    }
+}; // UnivariateExprPolynomial
+
 class UnivariatePolynomial : public Basic
 {
 private:
     int degree_;
     RCP<const Symbol> var_;
-    map_int_Expr dict_;
+    UnivariateExprPolynomial dict_;
 
 public:
     IMPLEMENT_TYPEID(UNIVARIATEPOLYNOMIAL)
@@ -141,7 +375,8 @@ public:
         return UnivariatePolynomial::from_vec(var, v);
     }
 
-    bool is_canonical(const int &degree, const map_int_Expr &dict) const;
+    bool is_canonical(const int &degree,
+                      const UnivariateExprPolynomial &dict) const;
     std::size_t __hash__() const;
     bool __eq__(const Basic &o) const;
     int compare(const Basic &o) const;
@@ -153,11 +388,7 @@ public:
     from_dict(const RCP<const Symbol> &var, map_int_Expr &&d);
     static RCP<const UnivariatePolynomial>
     from_vec(const RCP<const Symbol> &var, const std::vector<Expression> &v);
-    /*!
-    * Adds coef*var_**n to the dict_
-    */
-    static void dict_add_term(map_int_Expr &d, const Expression &coef,
-                              const int &n);
+
     Expression max_coef() const;
     //! Evaluates the UnivariatePolynomial at value x
     Expression eval(const Expression &x) const;
@@ -189,8 +420,13 @@ public:
     }
     inline const map_int_Expr &get_dict() const
     {
+        return dict_.get_dict();
+    }
+    const UnivariateExprPolynomial &get_dict2() const
+    {
         return dict_;
     }
+
 }; // UnivariatePolynomial
 
 //! Adding two UnivariatePolynomial a and b
@@ -202,192 +438,14 @@ RCP<const UnivariatePolynomial> neg_uni_poly(const UnivariatePolynomial &a);
 RCP<const UnivariatePolynomial> sub_uni_poly(const UnivariatePolynomial &a,
                                              const UnivariatePolynomial &b);
 //! Multiplying two UnivariatePolynomial a and b
-RCP<const UnivariatePolynomial> mul_uni_poly(RCP<const UnivariatePolynomial> a,
-                                             RCP<const UnivariatePolynomial> b);
+RCP<const UnivariatePolynomial> mul_uni_poly(const UnivariatePolynomial &a,
+                                             const UnivariatePolynomial &b);
 
 inline RCP<const UnivariatePolynomial>
 univariate_polynomial(RCP<const Symbol> i, map_int_Expr &&dict)
 {
     return UnivariatePolynomial::from_dict(i, std::move(dict));
 }
-
-class UnivariateExprPolynomial
-{
-private:
-    RCP<const UnivariatePolynomial> poly_;
-
-public:
-//! Construct UnivariateExprPolynomial from UnivariatePolynomial
-#if defined(HAVE_SYMENGINE_IS_CONSTRUCTIBLE)
-    template <
-        typename T,
-        typename = typename std::
-            enable_if<std::is_constructible<RCP<const UnivariatePolynomial>,
-                                            T &&>::value>::type>
-#else
-    template <typename T>
-#endif
-    UnivariateExprPolynomial(T &&o)
-        : poly_(std::forward<T>(o))
-    {
-    }
-    UnivariateExprPolynomial()
-    {
-    }
-    ~UnivariateExprPolynomial() SYMENGINE_NOEXCEPT
-    {
-    }
-    UnivariateExprPolynomial(const UnivariateExprPolynomial &) = default;
-    UnivariateExprPolynomial(UnivariateExprPolynomial &&other)
-        SYMENGINE_NOEXCEPT : poly_(std::move(other.poly_))
-    {
-    }
-    UnivariateExprPolynomial(int i)
-        : poly_(UnivariatePolynomial::create(symbol(""), {Expression(i)}))
-    {
-    }
-    UnivariateExprPolynomial(std::string varname)
-        : poly_(UnivariatePolynomial::create(symbol(varname), {0, 1}))
-    {
-    }
-    UnivariateExprPolynomial(RCP<const UnivariatePolynomial> p)
-        : poly_(std::move(p))
-    {
-    }
-    UnivariateExprPolynomial(Expression expr)
-        : poly_(UnivariatePolynomial::create(symbol(""), {expr}))
-    {
-    }
-    UnivariateExprPolynomial &operator=(const UnivariateExprPolynomial &)
-        = default;
-    UnivariateExprPolynomial &
-    operator=(UnivariateExprPolynomial &&other) SYMENGINE_NOEXCEPT
-    {
-        if (this != &other)
-            this->poly_ = std::move(other.poly_);
-        return *this;
-    }
-
-    friend std::ostream &operator<<(std::ostream &os,
-                                    const UnivariateExprPolynomial &expr)
-    {
-        os << expr.poly_->__str__();
-        return os;
-    }
-
-    friend UnivariateExprPolynomial operator+(const UnivariateExprPolynomial &a,
-                                              const UnivariateExprPolynomial &b)
-    {
-        return UnivariateExprPolynomial(add_uni_poly(*a.poly_, *b.poly_));
-    }
-
-    UnivariateExprPolynomial &operator+=(const UnivariateExprPolynomial &other)
-    {
-        poly_ = add_uni_poly(*poly_, *other.poly_);
-        return *this;
-    }
-
-    friend UnivariateExprPolynomial operator-(const UnivariateExprPolynomial &a,
-                                              const UnivariateExprPolynomial &b)
-    {
-        return UnivariateExprPolynomial(sub_uni_poly(*a.poly_, *b.poly_));
-    }
-
-    UnivariateExprPolynomial operator-() const
-    {
-        return neg_uni_poly(*this->poly_);
-    }
-
-    UnivariateExprPolynomial &operator-=(const UnivariateExprPolynomial &other)
-    {
-        poly_ = sub_uni_poly(*poly_, *other.poly_);
-        return *this;
-    }
-
-    friend UnivariateExprPolynomial operator*(const UnivariateExprPolynomial &a,
-                                              const UnivariateExprPolynomial &b)
-    {
-        return UnivariateExprPolynomial(mul_uni_poly(a.poly_, b.poly_));
-    }
-
-    friend UnivariateExprPolynomial operator/(const UnivariateExprPolynomial &a,
-                                              const Expression &b)
-    {
-        return UnivariateExprPolynomial(
-            mul_uni_poly(a.poly_, UnivariateExprPolynomial(1 / b).poly_));
-    }
-
-    UnivariateExprPolynomial &operator*=(const UnivariateExprPolynomial &other)
-    {
-        poly_ = mul_uni_poly(poly_, other.poly_);
-        return *this;
-    }
-
-    UnivariateExprPolynomial &operator/=(const Expression &other)
-    {
-        poly_ = mul_uni_poly(poly_, UnivariateExprPolynomial(1 / other).poly_);
-        return *this;
-    }
-
-    bool operator==(const UnivariateExprPolynomial &other) const
-    {
-        return eq(*poly_, *other.poly_);
-    }
-
-    bool operator==(int i) const
-    {
-        return eq(*poly_, *(UnivariateExprPolynomial(i).poly_));
-    }
-
-    bool operator!=(const UnivariateExprPolynomial &other) const
-    {
-        return not(*this == other);
-    }
-
-    //! Method to get UnivariatePolynomial from UnivariateExprPolynomial
-    const RCP<const UnivariatePolynomial> &get_univariate_poly() const
-    {
-        return poly_;
-    }
-
-    std::size_t __hash__() const
-    {
-        return poly_->hash();
-    }
-
-    const RCP<const Basic> get_basic() const
-    {
-        RCP<const Symbol> x = poly_->get_var();
-        umap_basic_num dict_;
-        RCP<const Number> coeff;
-        for (const auto &it : poly_->get_dict()) {
-            if (it.first != 0) {
-                auto term = mul(
-                    it.second.get_basic(),
-                    pow_ex(Expression(x), Expression(it.first)).get_basic());
-                RCP<const Number> coef;
-                coef = zero;
-                Add::coef_dict_add_term(outArg((coef)), dict_, one, term);
-            } else
-                coeff = rcp_static_cast<const Number>(it.second.get_basic());
-        }
-        return Add::from_dict(coeff, std::move(dict_));
-    }
-
-    int compare(const UnivariateExprPolynomial &other)
-    {
-        return poly_->compare(*other.poly_);
-    }
-
-    Expression find_cf(int deg) const
-    {
-        if (poly_->get_dict().find(deg) != poly_->get_dict().end()) {
-            return poly_->get_dict().at(deg);
-        } else {
-            return Expression(0);
-        }
-    }
-}; // UnivariateExprPolynomial
 
 } // SymEngine
 

--- a/symengine/printer.cpp
+++ b/symengine/printer.cpp
@@ -422,8 +422,70 @@ void StrPrinter::bvisit(const UnivariatePolynomial &x)
 void StrPrinter::bvisit(const UnivariateSeries &x)
 {
     std::ostringstream o;
-    o << x.get_poly() << " + O(" << x.get_var() << "**" << x.get_degree()
-      << ")";
+    bool first = true;
+    for (auto it = x.get_poly().get_dict().rbegin();
+         it != x.get_poly().get_dict().rend(); ++it) {
+        std::string t;
+        // if exponent is 0, then print only coefficient
+        if (it->first == 0) {
+            if (first) {
+                o << it->second;
+            } else {
+                t = parenthesizeLT(it->second.get_basic(), PrecedenceEnum::Mul);
+                if (t[0] == '-') {
+                    o << " - " << t.substr(1);
+                } else {
+                    o << " + " << t;
+                }
+            }
+            first = false;
+            continue;
+        }
+        // if the coefficient of a term is +1 or -1
+        if (it->second == 1 or it->second == -1) {
+            // in cases of -x, print -x
+            // in cases of x**2 - x, print - x
+            if (first) {
+                if (it->second == -1)
+                    o << "-";
+            } else {
+                o << " " << _print_sign(static_cast<const Integer &>(
+                                            *it->second.get_basic())
+                                            .as_mpz())
+                  << " ";
+            }
+        }
+        // if the coefficient of a term is 0, skip
+        else if (it->second == 0)
+            continue;
+        // same logic is followed as above
+        else {
+            // in cases of -2*x, print -2*x
+            // in cases of x**2 - 2*x, print - 2*x
+            if (first) {
+                o << parenthesizeLT(it->second.get_basic(), PrecedenceEnum::Mul)
+                  << "*";
+            } else {
+                t = parenthesizeLT(it->second.get_basic(), PrecedenceEnum::Mul);
+                if (t[0] == '-') {
+                    o << " - " << t.substr(1);
+                } else {
+                    o << " + " << t;
+                }
+                o << "*";
+            }
+        }
+        o << x.get_var();
+        // if exponent is not 1, print the exponent;
+        if (it->first > 1) {
+            o << "**" << it->first;
+        } else if (it->first < 0) {
+            o << "**(" << it->first << ")";
+        }
+        // corner cases of only first term handled successfully, switch the bool
+        first = false;
+    }
+    o << " + O(" << x.get_var() << "**" << x.get_degree() << ")";
     str_ = o.str();
 }
 

--- a/symengine/tests/basic/test_polynomial.cpp
+++ b/symengine/tests/basic/test_polynomial.cpp
@@ -404,8 +404,8 @@ TEST_CASE("Multiplication of two UnivariatePolynomial",
     RCP<const UnivariatePolynomial> b = univariate_polynomial(
         x, {{0, -1}, {1, -2}, {2, mul(integer(-1), symbol("a"))}});
 
-    RCP<const UnivariatePolynomial> c = mul_uni_poly(a, a);
-    RCP<const UnivariatePolynomial> d = mul_uni_poly(a, b);
+    RCP<const UnivariatePolynomial> c = mul_uni_poly(*a, *a);
+    RCP<const UnivariatePolynomial> d = mul_uni_poly(*a, *b);
 
     REQUIRE(c->__str__()
             == "a**2*x**4 + 2*a*b*x**3 + (2*a + b**2)*x**2 + 2*b*x + 1");
@@ -413,18 +413,18 @@ TEST_CASE("Multiplication of two UnivariatePolynomial",
                             "2*b)*x**2 + (-2 - b)*x - 1");
 
     RCP<const UnivariatePolynomial> f = univariate_polynomial(x, {{0, 2}});
-    REQUIRE(mul_uni_poly(a, f)->__str__() == "2*a*x**2 + 2*b*x + 2");
-    REQUIRE(mul_uni_poly(f, a)->__str__() == "2*a*x**2 + 2*b*x + 2");
+    REQUIRE(mul_uni_poly(*a, *f)->__str__() == "2*a*x**2 + 2*b*x + 2");
+    REQUIRE(mul_uni_poly(*f, *a)->__str__() == "2*a*x**2 + 2*b*x + 2");
 
     f = univariate_polynomial(y, {{0, 2}, {1, 4}});
-    CHECK_THROWS_AS(mul_uni_poly(a, f), std::runtime_error);
+    CHECK_THROWS_AS(mul_uni_poly(*a, *f), std::runtime_error);
 
     f = univariate_polynomial(x, std::map<int, Expression>{});
-    REQUIRE(mul_uni_poly(a, f)->__str__() == "0");
+    REQUIRE(mul_uni_poly(*a, *f)->__str__() == "0");
 
     a = univariate_polynomial(x, {{-2, 5}, {-1, 3}, {0, 1}, {1, 2}});
 
-    c = mul_uni_poly(a, b);
+    c = mul_uni_poly(*a, *b);
     REQUIRE(c->__str__() == "-2*a*x**3 + (-4 - a)*x**2 + (-4 - 3*a)*x + (-7 - "
                             "5*a) - 13*x**(-1) - 5*x**(-2)");
 }

--- a/symengine/tests/basic/test_series_generic.cpp
+++ b/symengine/tests/basic/test_series_generic.cpp
@@ -35,21 +35,18 @@ TEST_CASE("Create UnivariateSeries", "[UnivariateSeries]")
 {
     RCP<const Symbol> x = symbol("x");
     map_int_Expr adict_ = {{0, 1}, {1, 2}, {2, 1}};
-    UnivariateExprPolynomial apoly_(
-        univariate_polynomial(x, std::move(adict_)));
+    UnivariateExprPolynomial apoly_(adict_);
     RCP<const UnivariateSeries> P = univariate_series(x, 2, apoly_);
     REQUIRE(P->__str__() == "x**2 + 2*x + 1 + O(x**2)");
 
     map_int_Expr bdict_ = {{0, 1}, {1, 0}, {2, 2}, {3, 1}};
-    UnivariateExprPolynomial bpoly_(
-        UnivariatePolynomial::from_dict(x, std::move(bdict_)));
+    UnivariateExprPolynomial bpoly_(bdict_);
     RCP<const UnivariateSeries> Q = UnivariateSeries::create(x, 5, bpoly_);
     REQUIRE(Q->__str__() == "x**3 + 2*x**2 + 1 + O(x**5)");
 
     map_int_Expr cdict_
         = {{0, symbol("c")}, {1, symbol("b")}, {2, symbol("a")}};
-    UnivariateExprPolynomial cpoly_(
-        univariate_polynomial(x, std::move(cdict_)));
+    UnivariateExprPolynomial cpoly_(cdict_);
     RCP<const UnivariateSeries> R = UnivariateSeries::create(x, 3, cpoly_);
     REQUIRE(R->__str__() == "a*x**2 + b*x + c + O(x**3)");
 }
@@ -58,14 +55,11 @@ TEST_CASE("Adding two UnivariateSeries", "[UnivariateSeries]")
 {
     RCP<const Symbol> x = symbol("x");
     map_int_Expr adict_ = {{0, 1}, {1, 2}, {2, 1}};
-    UnivariateExprPolynomial apoly_(
-        univariate_polynomial(x, std::move(adict_)));
+    UnivariateExprPolynomial apoly_(adict_);
     map_int_Expr bdict_ = {{0, 2}, {1, 3}, {2, 4}};
-    UnivariateExprPolynomial bpoly_(
-        univariate_polynomial(x, std::move(bdict_)));
+    UnivariateExprPolynomial bpoly_(bdict_);
     map_int_Expr ddict_ = {{0, 3}, {1, 5}, {2, 5}};
-    UnivariateExprPolynomial dpoly_(
-        univariate_polynomial(x, std::move(ddict_)));
+    UnivariateExprPolynomial dpoly_(ddict_);
 
     RCP<const UnivariateSeries> a = UnivariateSeries::create(x, 5, apoly_);
     RCP<const UnivariateSeries> b = UnivariateSeries::create(x, 4, bpoly_);
@@ -83,17 +77,13 @@ TEST_CASE("Negative of a UnivariateSeries", "[UnivariateSeries]")
 {
     RCP<const Symbol> x = symbol("x");
     map_int_Expr adict_ = {{0, 1}, {1, 2}, {2, 1}};
-    UnivariateExprPolynomial apoly_(
-        univariate_polynomial(x, std::move(adict_)));
+    UnivariateExprPolynomial apoly_(adict_);
     map_int_Expr bdict_ = {{0, -1}, {1, -2}, {2, -1}};
-    UnivariateExprPolynomial bpoly_(
-        univariate_polynomial(x, std::move(bdict_)));
+    UnivariateExprPolynomial bpoly_(bdict_);
     map_int_Expr cdict_ = {{0, 1}, {1, symbol("a")}};
-    UnivariateExprPolynomial cpoly_(
-        univariate_polynomial(x, std::move(adict_)));
+    UnivariateExprPolynomial cpoly_(cdict_);
     map_int_Expr ddict_ = {{0, -1}, {1, mul(integer(-1), symbol("a"))}};
-    UnivariateExprPolynomial dpoly_(
-        univariate_polynomial(x, std::move(bdict_)));
+    UnivariateExprPolynomial dpoly_(ddict_);
 
     RCP<const UnivariateSeries> a = UnivariateSeries::create(x, 5, apoly_);
     RCP<const Basic> b = neg(a);
@@ -109,17 +99,13 @@ TEST_CASE("Subtracting two UnivariateSeries", "[UnivariateSeries]")
 {
     RCP<const Symbol> x = symbol("x");
     map_int_Expr adict_ = {{0, 1}, {1, 2}, {2, 1}};
-    UnivariateExprPolynomial apoly_(
-        univariate_polynomial(x, std::move(adict_)));
+    UnivariateExprPolynomial apoly_(adict_);
     map_int_Expr bdict_ = {{0, 2}, {1, 3}, {2, 4}};
-    UnivariateExprPolynomial bpoly_(
-        univariate_polynomial(x, std::move(bdict_)));
+    UnivariateExprPolynomial bpoly_(bdict_);
     map_int_Expr fdict_ = {{0, -1}, {1, -1}, {2, -3}};
-    UnivariateExprPolynomial fpoly_(
-        univariate_polynomial(x, std::move(fdict_)));
+    UnivariateExprPolynomial fpoly_(fdict_);
     map_int_Expr gdict_ = {{0, -1}, {1, -1}};
-    UnivariateExprPolynomial gpoly_(
-        univariate_polynomial(x, std::move(gdict_)));
+    UnivariateExprPolynomial gpoly_(gdict_);
 
     RCP<const UnivariateSeries> a = UnivariateSeries::create(x, 3, apoly_);
     RCP<const UnivariateSeries> b = UnivariateSeries::create(x, 4, bpoly_);
@@ -137,14 +123,10 @@ TEST_CASE("Multiplication of two UnivariateExprPolynomial with precision",
           "[UnivariateSeries]")
 {
     RCP<const Symbol> x = symbol("x");
-    UnivariateExprPolynomial a(
-        univariate_polynomial(x, {{0, 1}, {1, 2}, {2, 1}}));
-    UnivariateExprPolynomial b(
-        univariate_polynomial(x, {{0, -1}, {1, -2}, {2, -1}}));
-    UnivariateExprPolynomial c(
-        univariate_polynomial(x, {{0, 1}, {1, 4}, {2, 6}, {3, 4}}));
-    UnivariateExprPolynomial d(univariate_polynomial(
-        x, {{0, -1}, {1, -4}, {2, -6}, {3, -4}, {4, -1}}));
+    UnivariateExprPolynomial a({{0, 1}, {1, 2}, {2, 1}});
+    UnivariateExprPolynomial b({{0, -1}, {1, -2}, {2, -1}});
+    UnivariateExprPolynomial c({{0, 1}, {1, 4}, {2, 6}, {3, 4}});
+    UnivariateExprPolynomial d({{0, -1}, {1, -4}, {2, -6}, {3, -4}, {4, -1}});
 
     UnivariateExprPolynomial e = UnivariateSeries::mul(a, a, 4);
     UnivariateExprPolynomial f = UnivariateSeries::mul(a, b, 5);
@@ -157,16 +139,13 @@ TEST_CASE("Exponentiation of UnivariateExprPolynomial with precision",
           "[UnivariateSeries]")
 {
     RCP<const Symbol> x = symbol("x");
-    UnivariateExprPolynomial zero(univariate_polynomial(symbol(""), {{0, 0}}));
-    UnivariateExprPolynomial one(univariate_polynomial(symbol(""), {{0, 1}}));
-    UnivariateExprPolynomial a(
-        univariate_polynomial(x, {{0, 1}, {1, 2}, {2, 1}}));
-    UnivariateExprPolynomial b(
-        univariate_polynomial(x, {{0, -1}, {1, -2}, {2, -1}}));
-    UnivariateExprPolynomial c(
-        univariate_polynomial(x, {{0, 1}, {1, 4}, {2, 6}, {3, 4}}));
-    UnivariateExprPolynomial d(univariate_polynomial(
-        x, {{0, -1}, {1, -6}, {2, -15}, {3, -20}, {4, -15}}));
+    UnivariateExprPolynomial zero({{0, Expression(0)}});
+    UnivariateExprPolynomial one({{0, Expression(1)}});
+    UnivariateExprPolynomial a({{0, 1}, {1, 2}, {2, 1}});
+    UnivariateExprPolynomial b({{0, -1}, {1, -2}, {2, -1}});
+    UnivariateExprPolynomial c({{0, 1}, {1, 4}, {2, 6}, {3, 4}});
+    UnivariateExprPolynomial d(
+        {{0, -1}, {1, -6}, {2, -15}, {3, -20}, {4, -15}});
 
     UnivariateExprPolynomial e = UnivariateSeries::pow(a, 2, 4);
     UnivariateExprPolynomial f = UnivariateSeries::pow(b, 3, 5);
@@ -181,20 +160,17 @@ TEST_CASE("Exponentiation of UnivariateExprPolynomial with precision",
 TEST_CASE("Differentiation of UnivariateSeries", "[UnivariateSeries]")
 {
     RCP<const Symbol> x = symbol("x");
-    UnivariateExprPolynomial a(
-        univariate_polynomial(x, {{0, 1}, {1, 2}, {2, 1}}));
-    UnivariateExprPolynomial b(univariate_polynomial(x, {{0, 2}, {1, 2}}));
+    UnivariateExprPolynomial a({{0, 1}, {1, 2}, {2, 1}});
+    UnivariateExprPolynomial b({{0, 2}, {1, 2}});
     REQUIRE(UnivariateSeries::diff(a, UnivariateSeries::var("x")) == b);
 }
 
 TEST_CASE("Integration of UnivariateSeries", "[UnivariateSeries]")
 {
     RCP<const Symbol> x = symbol("x");
-    UnivariateExprPolynomial a(univariate_polynomial(x, {{-1, 1}}));
-    UnivariateExprPolynomial b(
-        univariate_polynomial(x, {{0, 1}, {1, 2}, {2, 3}}));
-    UnivariateExprPolynomial c(
-        univariate_polynomial(x, {{1, 1}, {2, 1}, {3, 1}}));
+    UnivariateExprPolynomial a({{-1, Expression(1)}});
+    UnivariateExprPolynomial b({{0, 1}, {1, 2}, {2, 3}});
+    UnivariateExprPolynomial c({{1, 1}, {2, 1}, {3, 1}});
     REQUIRE_THROWS_AS(
         UnivariateSeries::integrate(a, UnivariateSeries::var("x")),
         std::runtime_error);
@@ -204,9 +180,8 @@ TEST_CASE("Integration of UnivariateSeries", "[UnivariateSeries]")
 TEST_CASE("UnivariateSeries: compare, as_basic, as_dict", "[UnivariateSeries]")
 {
     RCP<const Symbol> x = symbol("x");
-    UnivariateExprPolynomial P(univariate_polynomial(x, {{0, 1}, {1, 2}}));
-    UnivariateExprPolynomial Q(
-        univariate_polynomial(x, {{0, 1}, {1, symbol("b")}, {2, 1}}));
+    UnivariateExprPolynomial P({{0, 1}, {1, 2}});
+    UnivariateExprPolynomial Q({{0, 1}, {1, symbol("b")}, {2, 1}});
     RCP<const UnivariateSeries> R = univariate_series(x, 4, P);
     RCP<const UnivariateSeries> S = univariate_series(x, 5, Q);
     umap_int_basic m = {{0, integer(1)}, {1, integer(2)}};


### PR DESCRIPTION
- Ignore flint executables
- Benchmark expansion of sin(x + x**2)*cos(x + x**2)
- Changed mul_uni_poly parameters to const & instead of RCP UnivariatePolynomial
- UnivariatePolynomial wraps UnivariateExprPolynomial, which has map_int_Expr dict; progress on changes to series_generic use of UnivariateExprPolynomial
- Add constant multiplication condition for faster performance, UnivariateExprPolynomial benchmark tests
- Refactor UnivariateSeries and most of its tests to work with new UnivariateExprPolynomial except as_basic(), moved 0 checking in UnivariatePolynomial to UnivariateExprPolynomial
- Check for 0 terms in all UnivariateExprPolynomial constructors, uncomment rest of test_series_generic
- Finish UnivariateSeries::as_basic()
- Fixed minor bugs, has formatting from test_format_local.sh
